### PR TITLE
Improves vue-page-title reactivity when using vue-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,35 @@ export default {
 </template>
 ```
 
+Or better, watch the title react:
+```vue
+<script>
+export default {
+  title: ctx => ctx.title,
+  data () {
+    return {
+      title: 'Start'
+    }
+  }
+  mounted () {
+    const servantTypes = [
+      'Ruler', 'Saber', 'Archer', 'Lancer', 'Rider', 'Caster', 'Berserker', 'Assassin'
+    ]
+    this.$interval = setInterval(() => {
+      this.title = servantTypes[Math.floor(Math.random() * servantTypes.length)]
+    }, 2000)
+  },
+  beforeDestroy () {
+    clearInterval(this.$interval)
+  }
+}
+</script>
+
+<template>
+  <div>{{ $title }}</div>
+</template>
+```
+
 It is also possible to generate a title dynamically, using a function. It receives as an argument the component instance.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -117,3 +117,15 @@ export default new VueRouter({
   routes
 })
 ```
+
+### Watching routes
+
+```javascript
+<script>
+export default {
+  title () {
+    return `My title is: ${this.$route.query.foo}`
+  }
+}
+</script>
+```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rollup": "^2.71.1",
     "rollup-plugin-terser": "^7.0.2",
     "vue": "^2.6.14",
+    "vue-router": "^3.6.0",
     "vue-template-compiler": "^2.6.14"
   },
   "engines": {

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -2,13 +2,26 @@ import { isFunction } from './utils'
 
 const pageTitleMixin = {
   created () {
-    const { title } = this.$options
+    this.setPageTitle()
+  },
+  watch: {
+    '$route.params' () {
+      this.setPageTitle()
+    },
+    '$route.query' () {
+      this.setPageTitle()
+    }
+  },
+  methods: {
+    setPageTitle () {
+      const { title } = this.$options
 
-    if (title !== undefined) {
+      if (title === undefined) {
+        return
+      }
+
       // allow use dinamic title system
-      this.$title = isFunction(title)
-        ? title.call(this, this)
-        : title
+      this.$title = isFunction(title) ? title.call(this, this) : title
     }
   }
 }

--- a/test/page-title.test.js
+++ b/test/page-title.test.js
@@ -43,6 +43,32 @@ test('function title', t => {
   t.is(wrapper2.html(), '<h1>Archer</h1>')
 })
 
+test('watch title', async (t) => {
+  const localVue = createLocalVue()
+
+  const component = {
+    title: ({ title }) => title,
+    data: () => ({ title: 'loops' }),
+    render (h) {
+      return h('h1', this.$title)
+    }
+  }
+
+  localVue.use(VuePageTitle)
+
+  const wrapper = shallowMount(component, { localVue })
+
+  t.is(wrapper.vm.$title, 'loops')
+  t.is(wrapper.html(), '<h1>loops</h1>')
+
+  wrapper.vm.title = 'breaks'
+
+  await localVue.nextTick()
+
+  t.is(wrapper.vm.$title, 'breaks')
+  t.is(wrapper.html(), '<h1>breaks</h1>')
+})
+
 test('shared title', async t => {
   const localVue = createLocalVue()
 

--- a/test/router-param.test.js
+++ b/test/router-param.test.js
@@ -1,0 +1,68 @@
+import VuePageTitle from '../src/index'
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import VueRouter from 'vue-router'
+import test from 'ava'
+
+test('should update the title when the params route changes', async (t) => {
+  const localVue = createLocalVue()
+  localVue.use(VuePageTitle)
+  localVue.use(VueRouter)
+
+  const component = {
+    title: (ctx) => ctx.getTitle(),
+    render (h) {
+      return h('h1', this.$title)
+    },
+    methods: {
+      getTitle () {
+        return this.$route.params.id
+      }
+    }
+  }
+
+  const routes = [
+    {
+      path: '/foo/:id',
+      name: 'foo'
+    },
+    {
+      path: '/bar/:id',
+      name: 'bar'
+    }
+  ]
+
+  const router = new VueRouter({
+    routes
+  })
+
+  await router.push({
+    name: 'foo',
+    params: {
+      id: 'foo'
+    }
+  })
+
+  const wrapper = shallowMount(component, {
+    localVue,
+    router,
+    sync: false
+  })
+
+  t.is(wrapper.vm.$title, 'foo')
+  t.is(wrapper.vm.$route.params.id, 'foo')
+  t.is(wrapper.html(), '<h1>foo</h1>')
+
+  await router.push({
+    name: 'bar',
+    params: {
+      id: 'bar'
+    }
+  })
+
+  await localVue.nextTick()
+
+  t.is(wrapper.vm.$title, 'bar')
+  t.is(wrapper.vm.$route.params.id, 'bar')
+  t.is(wrapper.html(), '<h1>bar</h1>')
+})

--- a/test/router-query.test.js
+++ b/test/router-query.test.js
@@ -1,0 +1,68 @@
+import VuePageTitle from '../src/index'
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import VueRouter from 'vue-router'
+import test from 'ava'
+
+test('should update the title when the query route changes', async (t) => {
+  const localVue = createLocalVue()
+  localVue.use(VuePageTitle)
+  localVue.use(VueRouter)
+
+  const component = {
+    title: (ctx) => ctx.getTitle(),
+    render (h) {
+      return h('h1', this.$title)
+    },
+    methods: {
+      getTitle () {
+        return this.$route.query.id
+      }
+    }
+  }
+
+  const routes = [
+    {
+      path: '/foo',
+      name: 'foo'
+    },
+    {
+      path: '/bar',
+      name: 'bar'
+    }
+  ]
+
+  const router = new VueRouter({
+    routes
+  })
+
+  await router.push({
+    name: 'foo',
+    query: {
+      id: 'foo'
+    }
+  })
+
+  const wrapper = shallowMount(component, {
+    localVue,
+    router,
+    sync: false
+  })
+
+  t.is(wrapper.vm.$title, 'foo')
+  t.is(wrapper.vm.$route.query.id, 'foo')
+  t.is(wrapper.html(), '<h1>foo</h1>')
+
+  await router.push({
+    name: 'bar',
+    query: {
+      id: 'bar'
+    }
+  })
+
+  await localVue.nextTick()
+
+  t.is(wrapper.vm.$title, 'bar')
+  t.is(wrapper.vm.$route.query.id, 'bar')
+  t.is(wrapper.html(), '<h1>bar</h1>')
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7431,11 +7431,19 @@ __metadata:
     rollup: ^2.71.1
     rollup-plugin-terser: ^7.0.2
     vue: ^2.6.14
+    vue-router: ^3.6.0
     vue-template-compiler: ^2.6.14
   peerDependencies:
     vue: ^2
   languageName: unknown
   linkType: soft
+
+"vue-router@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "vue-router@npm:3.6.0"
+  checksum: c9d95d507e02226f4387c565942813d1e360e34144149e46be791b887d3601b356757ab9b2a16d52e2dd43754f34510e1df5fb93f0f9ef77af9eb75eca16974c
+  languageName: node
+  linkType: hard
 
 "vue-template-compiler@npm:^2.6.14":
   version: 2.6.14


### PR DESCRIPTION
### Improves `vue-page-title` reactivity when using `vue-router`

Now the route are watched and when it changes the title function are re-called.

- Improves vue-page-title reactivity when using `vue-router`.
- Add `vue-router` usage tests.
- Update docs.

```javascript
<script>
export default {
  title () {
    return `My title is: ${this.$route.query.foo}`
  }
}
</script>
```